### PR TITLE
Update bitmexws.cpp

### DIFF
--- a/src/bitmexws.cpp
+++ b/src/bitmexws.cpp
@@ -60,7 +60,7 @@ BitmexWebsocket::~BitmexWebsocket()
 
 void BitmexWebsocket::on_message(const std::string &raw)
 {
-  std::async(std::launch::async, [this]() { this->maintain_heartbeat(); });
+  (void)std::async(std::launch::async, [this]() { this->maintain_heartbeat(); });
   if (raw == "pong")
   {
     return;


### PR DESCRIPTION
Fixes compile error from gcc 9.3.0 under Ubuntu 20.04